### PR TITLE
fix: 온보딩 애니메이션 오류 해결

### DIFF
--- a/src/pages/Onboarding/SetZipCode.tsx
+++ b/src/pages/Onboarding/SetZipCode.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from 'react';
+
 import Spinner from './components/Spinner';
 
 const SetZipCode = ({
@@ -6,7 +8,13 @@ const SetZipCode = ({
   setIsZipCodeSet: React.Dispatch<React.SetStateAction<boolean>>;
 }) => {
   const DUMMY_ZIPCODE = '122A2';
+  const [isBtnActive, setIsBtnActive] = useState<boolean>(false);
 
+  useEffect(() => {
+    setTimeout(() => {
+      setIsBtnActive(true);
+    }, 6300);
+  }, []);
   return (
     <>
       <header className="flex flex-col items-center">
@@ -16,13 +24,16 @@ const SetZipCode = ({
       </header>
       <section className="flex gap-2">
         {DUMMY_ZIPCODE.split('').map((char, index) => (
-          <Spinner key={index} target={`${char}`} index={index}></Spinner>
+          <Spinner key={index} target={char} index={index}></Spinner>
         ))}
       </section>
       <button
         type="button"
+        disabled={!isBtnActive}
         className="primary-btn body-m w-full py-2"
-        onClick={() => setIsZipCodeSet(true)}
+        onClick={() => {
+          setIsZipCodeSet(true);
+        }}
       >
         다음으로
       </button>

--- a/src/pages/Onboarding/UserInteraction.tsx
+++ b/src/pages/Onboarding/UserInteraction.tsx
@@ -1,18 +1,31 @@
 import { useState, useRef, useEffect } from 'react';
-import { Link } from 'react-router';
 import { twMerge } from 'tailwind-merge';
 
 import envelope from '@/assets/images/closed-letter.png';
-import envelopeTop from '@/assets/images/envelope-pink-back-top.png';
+// import envelopeTop from '@/assets/images/envelope-pink-back-top.png';
 import envelopeFront from '@/assets/images/opened-letter-front.png';
 
-export default function UserInteraction() {
+export default function UserInteraction({
+  setIsAnimationOver,
+}: {
+  setIsAnimationOver: React.Dispatch<React.SetStateAction<boolean>>;
+}) {
   const imgRef = useRef<HTMLImageElement>(null);
-  const [imgPos, setImgPos] = useState<{ top: number; width: number }>({ top: 0, width: 0 });
+  const [imgPos, setImgPos] = useState<{
+    top: number;
+    width: number;
+    height: number;
+    left: number;
+  }>({
+    top: 0,
+    width: 0,
+    height: 0,
+    left: 0,
+  });
   const [imgToBottom, setImgToBottom] = useState<boolean>(false);
 
   const [startAnimation, setStartAnimation] = useState<boolean>(false);
-  const [openAnimation, setOpenAnimation] = useState<boolean>(false);
+  // const [openAnimation, setOpenAnimation] = useState<boolean>(false);
   const [letterOutAnimation, setLetterOutAnimation] = useState<boolean>(false);
   const [envelopeOut, setEnvelopeOut] = useState<boolean>(false);
   const [finishAnimation, setFinishAnimation] = useState<boolean>(false);
@@ -20,7 +33,7 @@ export default function UserInteraction() {
   const handleLetterClick = () => {
     if (imgRef.current) {
       const rect = imgRef.current.getBoundingClientRect();
-      setImgPos({ top: rect.top, width: rect.width });
+      setImgPos({ top: rect.top, width: rect.width, height: rect.height, left: rect.left });
     }
     setStartAnimation(true);
     setTimeout(() => {
@@ -31,18 +44,18 @@ export default function UserInteraction() {
   useEffect(() => {
     if (imgToBottom) {
       setTimeout(() => {
-        setOpenAnimation(true);
+        setLetterOutAnimation(true);
       }, 1000);
     }
   }, [imgToBottom]);
 
-  useEffect(() => {
-    if (openAnimation) {
-      setTimeout(() => {
-        setLetterOutAnimation(true);
-      }, 2000);
-    }
-  }, [openAnimation]);
+  // useEffect(() => {
+  //   if (openAnimation) {
+  //     setTimeout(() => {
+  //       setLetterOutAnimation(true);
+  //     }, 2000);
+  //   }
+  // }, [openAnimation]);
 
   useEffect(() => {
     if (letterOutAnimation) {
@@ -56,9 +69,18 @@ export default function UserInteraction() {
     if (envelopeOut) {
       setTimeout(() => {
         setFinishAnimation(true);
-      }, 2000);
+      }, 1000);
     }
   }, [envelopeOut]);
+
+  useEffect(() => {
+    if (finishAnimation) {
+      setTimeout(() => {
+        setIsAnimationOver(true);
+      }, 2000);
+    }
+  }, [finishAnimation]);
+
   if (startAnimation === false) {
     return (
       <>
@@ -80,67 +102,78 @@ export default function UserInteraction() {
     );
   } else {
     return (
-      <>
+      <div className="relative h-[calc(100vh-110px)] w-full overflow-hidden">
         <img
           src={envelopeFront}
-          alt="분홍색 편지지"
+          alt=""
           className={twMerge(
-            `z-30 mx-10 h-auto rounded transition-transform duration-1000 ease-in-out`,
-            imgToBottom && 'translate-y-full',
+            `transform-translation z-30 mx-10 h-auto rounded`,
+            imgToBottom && !envelopeOut && 'animate-envelopeSink',
             envelopeOut && 'animate-envelopeOut',
           )}
           style={{
-            top: `${imgPos.top}px`,
+            top: `calc(${imgPos.top}px - 5rem)`,
             position: 'absolute',
             width: `${imgPos.width}px`,
+            left: '0px',
           }}
         />
-        {letterOutAnimation && (
-          <div
-            className="animate-expandScale to-gray-5 z-20 max-w-[600px] rounded-lg bg-linear-to-b from-white"
-            style={{
-              width: `${imgPos.width - imgPos.width * 0.1}px`,
-              bottom: `${imgPos.top - 0.7 * imgPos.top}px`,
-              top: `${imgPos.top - 0.5 * imgPos.top}px`,
-              position: 'absolute',
-            }}
-          ></div>
-        )}
-        {openAnimation && (
+        {/* {openAnimation && (
           <img
             src={envelopeTop}
             alt=""
             className={twMerge(
-              `z-10 mx-10 h-auto rounded transition-transform duration-1000 ease-in-out`,
-              imgToBottom && 'translate-y-full',
-              openAnimation && 'animate-openEnvelope',
+              `z-10 mx-10 h-auto rounded`,
+              openAnimation && !envelopeOut && 'animate-openEnvelope',
               envelopeOut && 'animate-envelopeOut',
             )}
             style={{
-              top: `${imgPos.top}px`,
+              bottom: `calc(${sinkRefTop.top}px - 7.5rem)`,
               position: 'absolute',
               width: `${imgPos.width}px`,
-              transformOrigin: 'bottom',
+              left: '0px',
             }}
           />
-        )}
+        )} */}
         <img
           src={envelope}
           alt="분홍색 편지지"
+          // ref={sinkRef}
+          // onAnimationEnd={(e) => {
+          //   if (e.animationName === 'envelopeSink') {
+          //     const rect = sinkRef.current?.getBoundingClientRect();
+          //     if (rect?.top) setSinkRefTop({ top: rect?.top });
+          //     console.log('Animation ended. boundingRect top:', rect?.top);
+          //   }
+          // }}
           className={twMerge(
-            `z-0 mx-10 h-auto rounded transition-transform duration-1000 ease-in-out`,
-            imgToBottom && 'translate-y-full',
+            `z-0 mx-10 h-auto rounded`,
+            imgToBottom && !envelopeOut && 'animate-envelopeSink',
             envelopeOut && 'animate-envelopeOut',
           )}
           style={{
-            top: `${imgPos.top}px`,
+            top: `calc(${imgPos.top}px - 5rem)`,
             position: 'absolute',
             width: `${imgPos.width}px`,
+            left: '0px',
           }}
         />
-        {/* TODO: 편지지 링크 */}
-        {finishAnimation && <Link to={'/'}></Link>}
-      </>
+        {letterOutAnimation && (
+          <div
+            className={twMerge(
+              'letter-gradient z-20 max-w-[600px] rounded-lg',
+              finishAnimation ? 'animate-fadeOut' : 'animate-expandScale',
+            )}
+            style={{
+              width: `${imgPos.width - imgPos.width * 0.1}px`,
+              bottom: `${0.9 * imgPos.height}px`,
+              top: `${imgPos.top - 0.7 * imgPos.top}px`,
+              position: 'absolute',
+              left: `58px`,
+            }}
+          ></div>
+        )}
+      </div>
     );
   }
 }

--- a/src/pages/Onboarding/WelcomeLetter.tsx
+++ b/src/pages/Onboarding/WelcomeLetter.tsx
@@ -1,0 +1,38 @@
+import { useNavigate } from 'react-router';
+
+export default function index() {
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const navigate = useNavigate();
+  return (
+    <main className="animate-fadeIn absolute inset-0 flex h-full w-full flex-col justify-end bg-white px-5 pt-7.5 pb-4 opacity-0">
+      <article className="basic-theme mt-7.5 mb-9 grow pl-4">
+        <h1 className="font-malang mt-15">To.따숨이</h1>
+        <h2 className="font-malang">환영합니다! 우리 함께 마음을 나누어 보아요</h2>
+        <section className="mt-9" style={{ fontFamily: 'KyoboHandwriting2020A' }}>
+          <p>안녕하세요, 따숨이님!</p>
+          <br />
+          <p>요즘 어떤 말을 하고싶으신가요?</p>
+          <p>36.5에서 따뜻한 마음의 편지를 나누어 보세요.</p>
+          <br />
+          <p>따뜻한 편지 문화를 위해 아래의 안내 사항을 숙지해주세요!</p>
+          <p>1. 욕설, 비방, 성희롱은 금지입니다.</p>
+          <p>
+            2. 만약 위의 이유로 신고를 당할 경우 경고를 받게 되고, 세번의 경고를 받게 되면 서비스를
+            이용하실 수 없습니다.
+          </p>
+          <p>3. 고민 편지에 대한 답장은 검수 후에 전달됩니다.</p>
+        </section>
+        <p className="font-malang mt-22">From.9황작물</p>
+      </article>
+      <button
+        className="primary-btn body-sb text-gray-60 h-fit w-full py-2"
+        onClick={() => {
+          navigate(`/`);
+          sessionStorage.removeItem('onBoarding');
+        }}
+      >
+        홈으로 가기
+      </button>
+    </main>
+  );
+}

--- a/src/pages/Onboarding/components/Spinner.tsx
+++ b/src/pages/Onboarding/components/Spinner.tsx
@@ -13,23 +13,9 @@ const Spinner = ({ target, index }: SpinnerProps) => {
   const SPEED = 100 + 10 * index;
   const [position, setPosition] = useState(0);
   const [isRunning, setIsRunning] = useState(true);
-  let LETTER_HEIGHT = 40;
+  const LETTER_HEIGHT = 45;
   const animationFrameRef = useRef<number | null>(null);
 
-  //TODO: 여러 기기에서 실효성 확인
-  // 웹에서는 없어도 될 것 같음
-  // calculate full height of the cycle
-  const containerRef = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    if (containerRef.current) {
-      console.log(LETTER_HEIGHT);
-      const letter = containerRef.current.querySelector('p');
-      if (letter) {
-        LETTER_HEIGHT = letter.getBoundingClientRect().height;
-      }
-    }
-    console.log(LETTER_HEIGHT);
-  }, []);
   const FULL_ROTATION = -TARGET_ARR.length * LETTER_HEIGHT;
 
   useEffect(() => {
@@ -72,7 +58,6 @@ const Spinner = ({ target, index }: SpinnerProps) => {
       style={{ willChange: 'transform' }}
     >
       <div
-        ref={containerRef}
         className="text-center transition-transform duration-500 ease-linear"
         style={{ transform: `translateY(${position}px)` }}
       >

--- a/src/pages/Onboarding/index.tsx
+++ b/src/pages/Onboarding/index.tsx
@@ -1,14 +1,41 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import SetZipCode from './SetZipCode';
 import UserInteraction from './UserInteraction';
+import WelcomeLetter from './welcomeLetter';
 
 const OnboardingPage = () => {
   const [isZipCodeSet, setIsZipCodeSet] = useState<boolean>(false);
+  const [isAnimationOver, setIsAnimationOver] = useState<boolean>(false);
 
+  useEffect(() => {
+    if (isZipCodeSet || isAnimationOver) {
+      sessionStorage.setItem(
+        'onBoarding',
+        JSON.stringify({ isZipCodeSet: isZipCodeSet, isAnimationOver: isAnimationOver }),
+      );
+    }
+  }, [isZipCodeSet, isAnimationOver]);
+
+  useEffect(() => {
+    const prevDataString = sessionStorage.getItem('onBoarding');
+    if (prevDataString) {
+      const newData = JSON.parse(prevDataString);
+      console.log(newData);
+      setIsZipCodeSet(newData.isZipCodeSet);
+      setIsAnimationOver(newData.isAnimationOver);
+      console.log('isZipCode', isZipCodeSet, 'isAnimation', isAnimationOver);
+    }
+  }, []);
   return (
     <main className="inset-0 mx-5 mt-20 mb-[1.875rem] flex grow flex-col items-center justify-between overflow-hidden">
-      {isZipCodeSet ? <UserInteraction /> : <SetZipCode setIsZipCodeSet={setIsZipCodeSet} />}
+      {!isZipCodeSet ? (
+        <SetZipCode setIsZipCodeSet={setIsZipCodeSet} />
+      ) : !isAnimationOver ? (
+        <UserInteraction setIsAnimationOver={setIsAnimationOver} />
+      ) : (
+        <WelcomeLetter />
+      )}
     </main>
   );
 };

--- a/src/styles/animations.css
+++ b/src/styles/animations.css
@@ -77,6 +77,14 @@
     }
   }
 
+  --animate-float: float 2s ease-in-out infinite;
+  --animate-openEnvelope: openEnvelope 2s ease-in-out forwards;
+  --animate-expandScale: expandScale 2s ease-in-out forwards;
+  --animate-envelopeSink: envelopeSink 1s ease-in-out forwards;
+  --animate-envelopeOut: envelopeOut 2s ease-in-out forwards;
+  --animate-fadeOut: letter-fadeOut 1s ease 1s forwards;
+  --animate-fadeIn: letter-fadeIn 1s ease 1s forwards;
+
   /* onBoarding */
   /* comment floating */
   @keyframes float {
@@ -86,6 +94,19 @@
     }
     50% {
       transform: translateY(5px);
+    }
+  }
+
+  /* onBoarding */
+  /* letter sinking */
+  @keyframes envelopeSink {
+    0% {
+      transform: translateY(0);
+      transform-origin: bottom;
+    }
+    100% {
+      transform: translateY(100%);
+      transform-origin: bottom;
     }
   }
 
@@ -119,10 +140,32 @@
   /* envelope out animation*/
   @keyframes envelopeOut {
     0% {
-      transform: translateY(0);
+      transform: translateY(100%);
     }
     100% {
-      transform: translateY(100vh);
+      transform: translateY(2000%);
+    }
+  }
+
+  /* onBoarding */
+  /* welcomeLetter fadeIn */
+  @keyframes letter-fadeIn {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+
+  /* onBoarding */
+  /* welcomeLetter fadeOut */
+  @keyframes letter-fadeOut {
+    from {
+      opacity: 1;
+    }
+    to {
+      opacity: 0;
     }
   }
 }

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -84,19 +84,7 @@
     border-style: solid !important;
   }
 
-  .animate-float {
-    animation: float 2s ease-in-out infinite;
-  }
-
-  .animate-openEnvelope {
-    animation: openEnvelope 2s ease-in-out forwards;
-  }
-
-  .animate-expandScale {
-    animation: expandScale 2s ease-in-out forwards;
-  }
-
-  .animate-envelopeOut {
-    animation: envelopeOut 2s ease-in-out forwards;
+  .letter-gradient {
+    background: linear-gradient(to bottom, #ffffff, #f2f2f2);
   }
 }


### PR DESCRIPTION
## ✅ 요약

- resolved #34
- 온보딩 편지 애니메이션 모바일 오류 해결
- 온보딩 단계에 따른 상태관리
- 온보딩이 끝난 후 홈으로 이동

## 🪄 변경사항

- 애니메이션 편지뚜껑 열리는 효과 없앰...ㅠ
- 온보딩 중 새로 고침 시 단계 유지
- 온보딩 이후 홈으로 이동하도록 설정

## 🖼️ 결과 화면

https://github.com/user-attachments/assets/4bd2cc43-0ed7-4dac-b5f2-31c9b5276e87

## 💬 리뷰어에게 전할 말

- 그냥 모바일이랑 웹에서 괜찮긴한데, 웹에서 모바일 버전을 보거나 화면을 줄이면 애니메이션 화면이 조금 깨집니다....
  - vw, vh에 따른 레이아웃 이슈인 것 같은데, absolute를 적용하니까 수습이 안돼서 일단은 그냥 넘어가는 걸로....
  - 혹시 좋은 생각 있으면 알려주세용
- 모바일 관련
  - tailwind gradient를 쓰면 모바일에 해당 컴포넌트가 렌더링이 안되는 것 같습니다..
      - 그래서 저는 그냥 style로 지정했어요.
  - 말풍선 꼭다리도 border로 지정시 렌더링이 되지 않는 문제가 있었으니, 혹시 관련해서 구현하신 분들은 한번씩 확인 해보세용
