### PR TITLE
Perf: 내 편지함 탄스택 쿼리 적용

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "gsap": "^3.12.7",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-intersection-observer": "^9.15.1",
     "react-router": "^7.1.5",
     "swiper": "^11.2.4",
     "tailwind-merge": "^3.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      react-intersection-observer:
+        specifier: ^9.15.1
+        version: 9.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-router:
         specifier: ^7.1.5
         version: 7.1.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2010,6 +2013,15 @@ packages:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
     peerDependencies:
       react: ^18.3.1
+
+  react-intersection-observer@9.15.1:
+    resolution: {integrity: sha512-vGrqYEVWXfH+AGu241uzfUpNK4HAdhCkSAyFdkMb9VWWXs6mxzBLpWCxEy9YcnDNY2g9eO6z7qUtTBdA9hc8pA==}
+    peerDependencies:
+      react: ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -4254,6 +4266,12 @@ snapshots:
       loose-envify: 1.4.0
       react: 18.3.1
       scheduler: 0.23.2
+
+  react-intersection-observer@9.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      react-dom: 18.3.1(react@18.3.1)
 
   react-is@16.13.1: {}
 

--- a/src/apis/mailBox.ts
+++ b/src/apis/mailBox.ts
@@ -10,10 +10,10 @@ export const getMailbox = async () => {
   }
 };
 
-export const getMailboxDetail = async (id: number) => {
+export const getMailboxDetail = async (id: number, pageParam: number) => {
   try {
-    // const response = await client.get(`/api/mailbox/${id}/page=${pageParam}&size=20`);
-    const response = await client.get(`/api/mailbox/${id}`);
+    const response = await client.get(`/api/mailbox/${id}?page=${pageParam}&size=20`);
+    // const response = await client.get(`/api/mailbox/${id}`);
 
     if (!response) throw new Error('error while fetching mailbox detail data');
     return response.data;

--- a/src/apis/mailBox.ts
+++ b/src/apis/mailBox.ts
@@ -12,7 +12,9 @@ export const getMailbox = async () => {
 
 export const getMailboxDetail = async (id: number) => {
   try {
+    // const response = await client.get(`/api/mailbox/${id}/page=${pageParam}&size=20`);
     const response = await client.get(`/api/mailbox/${id}`);
+
     if (!response) throw new Error('error while fetching mailbox detail data');
     return response.data;
   } catch (error) {

--- a/src/components/LetterWrapper.tsx
+++ b/src/components/LetterWrapper.tsx
@@ -1,3 +1,4 @@
+import { forwardRef } from 'react';
 import { twMerge } from 'tailwind-merge';
 
 interface LetterWrapperProps {
@@ -7,20 +8,23 @@ interface LetterWrapperProps {
   onClick?: (e: React.MouseEvent<HTMLElement>) => void;
 }
 
-const LetterWrapper = ({ isSender = false, className, children, onClick }: LetterWrapperProps) => {
-  return (
-    <article
-      className={twMerge(
-        'relative flex overflow-hidden rounded-sm p-4',
-        isSender ? 'letter-sender-bg' : 'letter-receiver-bg',
-        className,
-      )}
-      onClick={onClick}
-    >
-      <div className="z-10 w-full">{children}</div>
-      <div className="absolute inset-0 z-0 bg-white/50 blur-xl" />
-    </article>
-  );
-};
+const LetterWrapper = forwardRef<HTMLDivElement, LetterWrapperProps>(
+  ({ isSender = false, className, children, onClick }, ref) => {
+    return (
+      <article
+        className={twMerge(
+          'relative flex overflow-hidden rounded-sm p-4',
+          isSender ? 'letter-sender-bg' : 'letter-receiver-bg',
+          className,
+        )}
+        onClick={onClick}
+        ref={ref}
+      >
+        <div className="z-10 w-full">{children}</div>
+        <div className="absolute inset-0 z-0 bg-white/50 blur-xl" />
+      </article>
+    );
+  },
+);
 
 export default LetterWrapper;

--- a/src/pages/LetterBox/components/LetterBoxItem.tsx
+++ b/src/pages/LetterBox/components/LetterBoxItem.tsx
@@ -30,14 +30,15 @@ const LetterBoxItem = ({
       className="flex h-fit w-fit flex-col items-center"
       onClick={() => handleClickItem(boxId)}
     >
-      <div className="text-gray-70 flex h-25 w-20 flex-col gap-1.5 bg-linear-to-b from-[#D5B695] to-[#B3895D] p-1.5">
+      <div className="text-gray-70 window-bg flex h-25 w-20 flex-col gap-1.5 bg-linear-to-b p-1.5">
         <p
           className={twMerge(
             'body-m from-white px-1',
             isClosed
               ? 'bg-[repeating-linear-gradient(#D9D9D9,#D9D9D9_17px,#C2C2C2_17px,#C2C2C2_23px)]'
-              : 'bg-linear-to-b',
-            isChecked ? 'to-[#FFF5ED]' : 'to-[#FFF4F2]',
+              : isChecked
+                ? 'window-top-checked'
+                : 'window-top-unChecked',
           )}
         >
           {zipCode}
@@ -48,7 +49,7 @@ const LetterBoxItem = ({
           <div
             className={twMerge(
               'flex grow flex-col bg-linear-to-b',
-              isChecked ? 'from-[#FFF7E3] to-[#FFE197]' : 'from-[#FFF4F2] to-[#FFE6E3]',
+              isChecked ? 'window-bottom-checked' : 'window-bottom-unChecked',
             )}
           >
             <p className="body-r mt-auto mr-[1px] text-right">{letterCount}통</p>

--- a/src/pages/LetterBox/index.tsx
+++ b/src/pages/LetterBox/index.tsx
@@ -61,7 +61,7 @@ const LetterBoxPage = () => {
                     boxId={data.letterMatchingId}
                     key={index}
                     zipCode={data.oppositeZipCode}
-                    letterCount={90}
+                    letterCount={data.letterCount}
                     isChecked={data.oppositeRead}
                     isClosed={data.active}
                   />

--- a/src/pages/LetterBoxDetail/components/LetterPreview.tsx
+++ b/src/pages/LetterBoxDetail/components/LetterPreview.tsx
@@ -1,3 +1,4 @@
+import { forwardRef } from 'react';
 import { useNavigate } from 'react-router';
 
 import LetterWrapper from '@/components/LetterWrapper';
@@ -14,18 +15,18 @@ interface LetterPreviewProps {
   isClosed: boolean;
   zipCode: string;
 }
-const LetterPreview = ({
-  id,
-  date,
-  title,
-  isSend,
-  checked,
-  isShareMode = false,
-  onToggle,
-  isClosed,
-  zipCode,
-}: LetterPreviewProps) => {
-  // 차단된 편지인경우 편지 보내기 disable
+const LetterPreview = forwardRef<HTMLDivElement, LetterPreviewProps>((props, ref) => {
+  const {
+    id,
+    date,
+    title,
+    isSend,
+    checked,
+    isShareMode = false,
+    onToggle,
+    isClosed,
+    zipCode,
+  } = props;
   const navigate = useNavigate();
 
   const handleItemClick = (id: number) => {
@@ -40,7 +41,7 @@ const LetterPreview = ({
 
   if (isShareMode)
     return (
-      <LetterWrapper isSender={isSend}>
+      <LetterWrapper isSender={isSend} ref={ref}>
         <div className="mb-3 flex items-center justify-between">
           <p className="body-r text-gray-80">{formatDate(date)}</p>
           <label htmlFor={`${id}`} className="relative">
@@ -59,11 +60,11 @@ const LetterPreview = ({
     );
 
   return (
-    <LetterWrapper isSender={isSend} onClick={() => handleItemClick(id)}>
+    <LetterWrapper isSender={isSend} onClick={() => handleItemClick(id)} ref={ref}>
       <p className="body-r text-gray-80 mb-3">{date}</p>
       <p className="body-m text-gray-80 line-clamp-1 break-all">{title}</p>
     </LetterWrapper>
   );
-};
+});
 
 export default LetterPreview;

--- a/src/pages/LetterBoxDetail/components/LetterPreview.tsx
+++ b/src/pages/LetterBoxDetail/components/LetterPreview.tsx
@@ -1,6 +1,7 @@
 import { useNavigate } from 'react-router';
 
 import LetterWrapper from '@/components/LetterWrapper';
+import formatDate from '@/utils/formatDate';
 
 interface LetterPreviewProps {
   id: number;
@@ -41,7 +42,7 @@ const LetterPreview = ({
     return (
       <LetterWrapper isSender={isSend}>
         <div className="mb-3 flex items-center justify-between">
-          <p className="body-r text-gray-80">{date}</p>
+          <p className="body-r text-gray-80">{formatDate(date)}</p>
           <label htmlFor={`${id}`} className="relative">
             <input
               id={`${id}`}

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -90,22 +90,22 @@
 
   /* letter-box */
   .window-bg {
-    background: linear-gradient(to bottom, #d5b695, #b3895d);
+    background: linear-gradient(to bottom, #d5b695, #b3895d) !important;
   }
 
   .window-top-checked {
-    background: linear-gradient(to bottom, #ffffff, #fff5ed);
+    background: linear-gradient(to bottom, #ffffff, #fff5ed) !important;
   }
 
   .window-top-unChecked {
-    background: linear-gradient(to bottom, #ffffff, #fff4f2);
+    background: linear-gradient(to bottom, #ffffff, #fff4f2) !important;
   }
 
   .window-bottom-checked {
-    background: linear-gradient(to bottom, #FFF7E3, #FFE197);
+    background: linear-gradient(to bottom, #fff7e3, #ffe197) !important;
   }
 
   .window-bottom-unChecked {
-    background: linear-gradient(to bottom, #FFF4F2, #FFE6E3);
+    background: linear-gradient(to bottom, #fff4f2, #ffe6e3) !important;
   }
 }

--- a/src/styles/utilities.css
+++ b/src/styles/utilities.css
@@ -87,4 +87,25 @@
   .letter-gradient {
     background: linear-gradient(to bottom, #ffffff, #f2f2f2);
   }
+
+  /* letter-box */
+  .window-bg {
+    background: linear-gradient(to bottom, #d5b695, #b3895d);
+  }
+
+  .window-top-checked {
+    background: linear-gradient(to bottom, #ffffff, #fff5ed);
+  }
+
+  .window-top-unChecked {
+    background: linear-gradient(to bottom, #ffffff, #fff4f2);
+  }
+
+  .window-bottom-checked {
+    background: linear-gradient(to bottom, #FFF7E3, #FFE197);
+  }
+
+  .window-bottom-unChecked {
+    background: linear-gradient(to bottom, #FFF4F2, #FFE6E3);
+  }
 }

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,0 +1,11 @@
+const formatDate = (isoString: string) => {
+  const date = new Date(isoString);
+  return date
+    .toLocaleDateString('ko-KR', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    })
+    .replace(/-/g, '.');
+};
+export default formatDate;


### PR DESCRIPTION
## ✅ 요약

- resolved #42 
- 내 편지함 tanstack query 적용

## 🪄 변경사항

- 내 편지함
  - useQuery, staleTime, gcTime 설정해서 데이터 관리
  - 모바일에서 창문 보이지 않는 문제 해결
- 내 편지함 상세
  - 편지 리스트 무한 스크롤 적용
  - 공유, 차단 기능 useMutation 으로 변경

## 🖼️ 결과 화면

## 💬 리뷰어에게 전할 말 (선택)

- 요청 실패/ 성공 시 toastUI를 띄워주면 좋을 것 같아요!
  - 일단 추가기능으로 넣고, 추가기능의 우선순위를 조금 높일까용?
- skeleton UI도 넣으면 좋겠다.. 생각하고 있습니다. 
그냥 얘기만....ㅎㅎ
