### PR TITLE
fix: 편지함 오류 수정

### DIFF
--- a/src/apis/client.ts
+++ b/src/apis/client.ts
@@ -52,10 +52,8 @@ client.interceptors.response.use(
 
     if (!originalRequest) return Promise.reject(error);
 
-    if (
-      originalRequest.url === '/auth/reissue' ||
-      originalRequest.url.includes('/api/auth/token?state=')
-    ) {
+    if (originalRequest.url === '/auth/reissue') {
+      logout();
       return Promise.reject(error);
     }
 
@@ -102,6 +100,7 @@ client.interceptors.response.use(
         return Promise.reject(e);
       }
     }
+    logout();
     return Promise.reject(error);
   },
 );

--- a/src/apis/client.ts
+++ b/src/apis/client.ts
@@ -75,9 +75,6 @@ client.interceptors.response.use(
       originalRequest._retry = true;
 
       if (isRefreshing) {
-        console.log('request', originalRequest);
-        console.log('isRefreshing');
-        console.log('failedQueue', failedQueue);
         try {
           return new Promise((resolve, reject) => {
             failedQueue.push({
@@ -108,8 +105,6 @@ client.interceptors.response.use(
         }
       }
     }
-    if (isLoggedIn) logout();
-    console.error('Failed to refresh token', error);
     return Promise.reject(error);
   },
 );

--- a/src/apis/mailBox.ts
+++ b/src/apis/mailBox.ts
@@ -12,7 +12,7 @@ export const getMailbox = async () => {
 
 export const getMailboxDetail = async (id: number, pageParam: number) => {
   try {
-    const response = await client.get(`/api/mailbox/${id}?page=${pageParam}&size=20`);
+    const response = await client.get(`/api/mailbox/${id}/detail?page=${pageParam}&size=20`);
 
     if (!response) throw new Error('error while fetching mailbox detail data');
     return response.data;

--- a/src/apis/mailBox.ts
+++ b/src/apis/mailBox.ts
@@ -13,7 +13,6 @@ export const getMailbox = async () => {
 export const getMailboxDetail = async (id: number, pageParam: number) => {
   try {
     const response = await client.get(`/api/mailbox/${id}?page=${pageParam}&size=20`);
-    // const response = await client.get(`/api/mailbox/${id}`);
 
     if (!response) throw new Error('error while fetching mailbox detail data');
     return response.data;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -21,5 +21,5 @@ createRoot(document.getElementById('root')!).render(
       <App />
     </BrowserRouter>
   </QueryClientProvider>,
-  // </StrictMode>,
+  // </StrictMode>
 );

--- a/src/pages/LetterBox/index.tsx
+++ b/src/pages/LetterBox/index.tsx
@@ -21,6 +21,7 @@ const fetchMailLists = async () => {
   const response = await getMailbox();
   if (!response) throw new Error();
   const data: LetterBoxData[] = response.data;
+  console.log(data);
   // 정렬?
   return data;
 };
@@ -63,7 +64,7 @@ const LetterBoxPage = () => {
                     zipCode={data.oppositeZipCode}
                     letterCount={data.letterCount}
                     isChecked={data.oppositeRead}
-                    isClosed={data.active}
+                    isClosed={!data.active}
                   />
                 )),
               ).map((row, index) =>

--- a/src/pages/LetterBoxDetail/components/LetterPreview.tsx
+++ b/src/pages/LetterBoxDetail/components/LetterPreview.tsx
@@ -61,7 +61,7 @@ const LetterPreview = forwardRef<HTMLDivElement, LetterPreviewProps>((props, ref
 
   return (
     <LetterWrapper isSender={isSend} onClick={() => handleItemClick(id)} ref={ref}>
-      <p className="body-r text-gray-80 mb-3">{date}</p>
+      <p className="body-r text-gray-80 mb-3">{formatDate(date)}</p>
       <p className="body-m text-gray-80 line-clamp-1 break-all">{title}</p>
     </LetterWrapper>
   );

--- a/src/pages/LetterBoxDetail/index.tsx
+++ b/src/pages/LetterBoxDetail/index.tsx
@@ -35,7 +35,7 @@ const LetterBoxDetailPage = () => {
     useInfiniteQuery({
       queryKey: ['mailBoxDetail', userInfo.id],
       queryFn: async ({ pageParam }) => {
-        console.log(`Fetching page: ${pageParam}`); // 디버깅용
+        console.log(`Fetching page: ${pageParam}`);
         const response = await getMailboxDetail(userInfo.id, pageParam);
         console.log(response.data);
         return response.data;
@@ -73,7 +73,7 @@ const LetterBoxDetailPage = () => {
 
   const shareMutation = useMutation({
     // Todo : useAuthStore -> myId 대체
-    mutationFn: () => postShareProposals(selected, 1, userInfo.id, shareComment),
+    mutationFn: () => postShareProposals(selected, userInfo.id, shareComment),
     onSuccess: () => {
       toggleShareMode();
       setShareComment('');

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,11 +1,12 @@
 const formatDate = (isoString: string) => {
-  const date = new Date(isoString);
+  const trimmedIsoString = isoString.split('.')[0];
+  const date = new Date(trimmedIsoString);
   return date
     .toLocaleDateString('ko-KR', {
       year: 'numeric',
       month: '2-digit',
       day: '2-digit',
     })
-    .replace(/-/g, '.');
+    .replace(/\./g, '.');
 };
 export default formatDate;


### PR DESCRIPTION
## ✅ 요약

- 실수로 다른 이슈 브랜치에 올려버렸지만.. 편지함 오류 수정입니다..

## 🪄 변경사항

- 배포된 api 바탕으로 편지함 오류 수정했습니다.
- 편지함 차단 여부에 따른 ui 가 반대로 되어있던 문제도 해결했습니다.
- 편지함 상세페이지에서 시간이 잘못되어있어서 수정했습니다.
- 아직 안된 문제
  - [ ] 편지 공유 요청은 500에러가 나서 정현님께서 확인해주신다고 하십니다!
 
- client.ts 변경 사항 관련 -> reissue 문제가 분명히 당시엔 해결됐는데, 오늘 아침에 해보니 다시 오류가 생긴것 같아서 강사님께 오늘은 진짜로 다시 여쭤보겠습니다.. 이 부분 무시하시면 됩니다!
