### PR TITLE
feat: 롤링페이퍼 배포된 api로 연결 수정

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -31,6 +31,7 @@ export default tseslint.config(
       ...reactHooks.configs.recommended.rules,
       'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
       '@tanstack/query/exhaustive-deps': 'error',
+      '@typescript-eslint/no-empty-object-type': off,
       'import/order': [
         'error',
         {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import AdminPage from './pages/Admin';
 import FilteredLetterManage from './pages/Admin/FilteredLetter';
 import FilteringManage from './pages/Admin/Filtering';
 import ReportManage from './pages/Admin/Report';
+import AdminRollingPaper from './pages/Admin/RollingPaper';
 import AuthCallbackPage from './pages/Auth';
 import Home from './pages/Home';
 import Landing from './pages/Landing';
@@ -69,6 +70,7 @@ const App = () => {
           <Route path="report" element={<ReportManage />} />
           <Route path="badwords" element={<FilteringManage />} />
           <Route path="filtered-letter" element={<FilteredLetterManage />} />
+          <Route path="rolling-paper" element={<AdminRollingPaper />} />
         </Route>
       </Route>
     </Routes>

--- a/src/apis/rolling.ts
+++ b/src/apis/rolling.ts
@@ -48,3 +48,15 @@ export const postNewRollingPaper = async (title: string) => {
     throw error;
   }
 };
+
+export const getRollingPaperList = async (): Promise<RollingPaperList> => {
+  try {
+    const {
+      data: { data },
+    } = await client.get('/api/admin/event-posts');
+    return data;
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};

--- a/src/apis/rolling.ts
+++ b/src/apis/rolling.ts
@@ -36,3 +36,15 @@ export const deleteRollingPaperComment = async (commentId: string | number) => {
     throw error;
   }
 };
+
+export const postNewRollingPaper = async (title: string) => {
+  try {
+    const {
+      data: { data },
+    } = await client.post('/api/admin/event-posts', { title });
+    return data;
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};

--- a/src/apis/rolling.ts
+++ b/src/apis/rolling.ts
@@ -70,3 +70,16 @@ export const deleteRollingPaper = async (eventPostId: number | string) => {
     throw error;
   }
 };
+
+export const patchRollingPaper = async (eventPostId: number | string) => {
+  try {
+    const {
+      data: { data },
+    } = await client.patch(`/api/admin/event-posts/${eventPostId}/status`);
+    console.log(data);
+    return data;
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};

--- a/src/apis/rolling.ts
+++ b/src/apis/rolling.ts
@@ -60,3 +60,13 @@ export const getRollingPaperList = async (): Promise<RollingPaperList> => {
     throw error;
   }
 };
+
+export const deleteRollingPaper = async (eventPostId: number | string) => {
+  try {
+    const { data } = await client.delete(`/api/admin/event-posts/${eventPostId}`);
+    return data;
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
+};

--- a/src/components/NoticeRollingPaper.tsx
+++ b/src/components/NoticeRollingPaper.tsx
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+import { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router';
 import { twMerge } from 'tailwind-merge';
 
@@ -10,6 +11,30 @@ const NoticeRollingPaper = () => {
     queryKey: ['notice-rolling-paper'],
     queryFn: () => getCurrentRollingPaper(),
   });
+
+  const [activeAnimate, setActiveAnimate] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const textRef = useRef<HTMLParagraphElement>(null);
+
+  useEffect(() => {
+    const containerElement = containerRef.current;
+    const element = textRef.current;
+
+    if (containerElement && element) {
+      const textWidth = element.scrollWidth;
+      const containerWidth = containerElement.offsetWidth;
+
+      if (textWidth > containerWidth) {
+        const animationDuration = (textWidth / 10) * 0.3;
+        const totalDuration = Math.max(animationDuration, 10);
+        document.documentElement.style.setProperty('--marquee-duration', `${totalDuration}s`);
+
+        setActiveAnimate(true);
+      } else {
+        setActiveAnimate(false);
+      }
+    }
+  }, [data?.title]);
 
   const noticeText = data?.title;
 
@@ -23,8 +48,13 @@ const NoticeRollingPaper = () => {
         )}
       >
         <NoticeIcon className="h-6 w-6 shrink-0 text-gray-50" />
-        <div className="w-full overflow-hidden">
-          <p className="body-sb animate-marquee whitespace-nowrap">{noticeText}</p>
+        <div ref={containerRef} className="w-full overflow-hidden whitespace-nowrap">
+          <p
+            ref={textRef}
+            className={twMerge('body-sb inline-block', activeAnimate && 'animate-marquee')}
+          >
+            {noticeText}
+          </p>
         </div>
       </article>
     </Link>

--- a/src/components/NoticeRollingPaper.tsx
+++ b/src/components/NoticeRollingPaper.tsx
@@ -7,7 +7,7 @@ import { getCurrentRollingPaper } from '@/apis/rolling';
 import { NoticeIcon } from '@/assets/icons';
 
 const NoticeRollingPaper = () => {
-  const { data } = useQuery({
+  const { data, error } = useQuery({
     queryKey: ['notice-rolling-paper'],
     queryFn: () => getCurrentRollingPaper(),
   });
@@ -17,26 +17,30 @@ const NoticeRollingPaper = () => {
   const textRef = useRef<HTMLParagraphElement>(null);
 
   useEffect(() => {
-    const containerElement = containerRef.current;
-    const element = textRef.current;
+    if (data?.title) {
+      const containerElement = containerRef.current;
+      const element = textRef.current;
 
-    if (containerElement && element) {
-      const textWidth = element.scrollWidth;
-      const containerWidth = containerElement.offsetWidth;
+      if (containerElement && element) {
+        const textWidth = element.scrollWidth;
+        const containerWidth = containerElement.offsetWidth;
 
-      if (textWidth > containerWidth) {
-        const animationDuration = (textWidth / 10) * 0.3;
-        const totalDuration = Math.max(animationDuration, 10);
-        document.documentElement.style.setProperty('--marquee-duration', `${totalDuration}s`);
+        if (textWidth > containerWidth) {
+          const animationDuration = (textWidth / 10) * 0.3;
+          const totalDuration = Math.max(animationDuration, 10);
+          document.documentElement.style.setProperty('--marquee-duration', `${totalDuration}s`);
 
-        setActiveAnimate(true);
-      } else {
-        setActiveAnimate(false);
+          setActiveAnimate(true);
+        } else {
+          setActiveAnimate(false);
+        }
       }
     }
   }, [data?.title]);
 
   const noticeText = data?.title;
+
+  if (error || !noticeText) return null;
 
   return (
     <Link to={`/board/rolling/${data?.eventPostId}`}>

--- a/src/pages/Admin/RollingPaper.tsx
+++ b/src/pages/Admin/RollingPaper.tsx
@@ -16,7 +16,6 @@ export default function AdminRollingPaper() {
     queryKey: ['admin-rolling-paper'],
     queryFn: getRollingPaperList,
   });
-  console.log(data);
 
   return (
     <>
@@ -36,21 +35,28 @@ export default function AdminRollingPaper() {
         </section>
         {isLoading && <p className="mt-20 text-center">Loading...</p>}
         {isSuccess && (
-          <table className="mt-5 table-auto">
-            <thead>
-              <tr className="bg-primary-3 border-gray-40 h-14 border-b">
-                <th className="w-14 text-center">ID</th>
-                <th className="text-left">제목</th>
-                <th className="w-30 text-center">상태</th>
-                <th></th>
-              </tr>
-            </thead>
-            <tbody>
-              {data.content.map((rollingPaper) => (
-                <RollingPaperItem key={rollingPaper.eventPostId} information={rollingPaper} />
-              ))}
-            </tbody>
-          </table>
+          <>
+            <table className="mt-5 table-auto">
+              <thead>
+                <tr className="bg-primary-3 border-gray-40 h-14 border-b">
+                  <th className="w-14 text-center">ID</th>
+                  <th className="text-left">제목</th>
+                  <th className="w-30 text-center">상태</th>
+                  <th className="w-6"></th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.content.map((rollingPaper) => (
+                  <RollingPaperItem key={rollingPaper.eventPostId} information={rollingPaper} />
+                ))}
+              </tbody>
+            </table>
+            {data.content.length === 0 && (
+              <span className="my-10 text-center text-gray-50">
+                아직 생성된 롤링페이퍼가 없어요
+              </span>
+            )}
+          </>
         )}
         {/* TODO: 페이지네이션 적용 */}
       </WrapperFrame>

--- a/src/pages/Admin/RollingPaper.tsx
+++ b/src/pages/Admin/RollingPaper.tsx
@@ -1,14 +1,22 @@
+import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
 
-import { AddIcon, AlarmIcon, DeleteIcon } from '@/assets/icons';
+import { getRollingPaperList } from '@/apis/rolling';
+import { AddIcon, AlarmIcon } from '@/assets/icons';
 
 import AddRollingPaperModal from './components/AddRollingPaperModal';
 import PageTitle from './components/AdminPageTitle';
+import RollingPaperItem from './components/RollingPaperItem';
 import WrapperFrame from './components/WrapperFrame';
 import WrapperTitle from './components/WrapperTitle';
 
 export default function AdminRollingPaper() {
   const [activeModal, setActiveModal] = useState(false);
+  const { data, isLoading, isSuccess } = useQuery({
+    queryKey: ['admin-rolling-paper'],
+    queryFn: getRollingPaperList,
+  });
+  console.log(data);
 
   return (
     <>
@@ -26,55 +34,25 @@ export default function AdminRollingPaper() {
             롤링페이퍼 생성
           </button>
         </section>
-        <table className="mt-5 table-auto">
-          <thead>
-            <tr className="bg-primary-3 border-gray-40 h-14 border-b">
-              <th className="w-14 text-center">ID</th>
-              <th className="text-left">제목</th>
-              <th className="w-30 text-center">쌓인 편지 수</th>
-              <th className="w-30 text-center">상태</th>
-              <th></th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr className="border-gray-40 h-14 border-b">
-              <td className="w-14 text-center">1</td>
-              <td className="text-left">
-                침수 피해를 복구중인 포스코 임직원 분들에게 응원의 메시지를 보내주세요!
-              </td>
-              <td className="w-30 text-center">12</td>
-              <td className="text-center">
-                <span className="rounded-full border border-amber-500 bg-amber-100/70 px-4 py-1.5 whitespace-nowrap text-amber-500">
-                  진행 중
-                </span>
-              </td>
-              <td></td>
-            </tr>
-            <tr className="border-gray-40 h-14 border-b">
-              <td className="w-14 text-center">2</td>
-              <td className="text-left">
-                침수 피해를 복구중인 포스코 임직원 분들에게 응원의 메시지를 보내주세요!
-              </td>
-              <td className="w-30 text-center">12</td>
-              <td className="w-30 px-2 text-center">
-                <button
-                  type="button"
-                  className="hover:bg-gray-10 text-gray-60 rounded-md px-3 py-1 hover:text-black"
-                >
-                  진행하기
-                </button>
-              </td>
-              <td>
-                <button
-                  type="button"
-                  className="text-gray-60 flex items-center justify-center p-1 hover:text-black"
-                >
-                  <DeleteIcon className="h-5 w-5" />
-                </button>
-              </td>
-            </tr>
-          </tbody>
-        </table>
+        {isLoading && <p className="mt-20 text-center">Loading...</p>}
+        {isSuccess && (
+          <table className="mt-5 table-auto">
+            <thead>
+              <tr className="bg-primary-3 border-gray-40 h-14 border-b">
+                <th className="w-14 text-center">ID</th>
+                <th className="text-left">제목</th>
+                <th className="w-30 text-center">상태</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.content.map((rollingPaper) => (
+                <RollingPaperItem key={rollingPaper.eventPostId} information={rollingPaper} />
+              ))}
+            </tbody>
+          </table>
+        )}
+        {/* TODO: 페이지네이션 적용 */}
       </WrapperFrame>
     </>
   );

--- a/src/pages/Admin/components/AddRollingPaperModal.tsx
+++ b/src/pages/Admin/components/AddRollingPaperModal.tsx
@@ -1,5 +1,7 @@
+import { useMutation } from '@tanstack/react-query';
 import { ChangeEvent, FormEvent, useState } from 'react';
 
+import { postNewRollingPaper } from '@/apis/rolling';
 import ModalOverlay from '@/components/ModalOverlay';
 
 interface AddRollingPaperModalProps {
@@ -9,6 +11,18 @@ interface AddRollingPaperModalProps {
 export default function AddRollingPaperModal({ onClose }: AddRollingPaperModalProps) {
   const [title, setTitle] = useState('');
   const [error, setError] = useState('');
+
+  const { mutate } = useMutation({
+    mutationFn: () => postNewRollingPaper(title),
+    onSuccess: () => {
+      setTitle('');
+      setError('');
+      onClose();
+    },
+    onError: () => {
+      setError('편지 작성에 실패했어요. 다시 시도해주세요.');
+    },
+  });
 
   const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
     setTitle(e.target.value);
@@ -21,7 +35,7 @@ export default function AddRollingPaperModal({ onClose }: AddRollingPaperModalPr
       return;
     }
 
-    console.log(title);
+    mutate();
   };
 
   return (

--- a/src/pages/Admin/components/AddRollingPaperModal.tsx
+++ b/src/pages/Admin/components/AddRollingPaperModal.tsx
@@ -1,4 +1,4 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { ChangeEvent, FormEvent, useState } from 'react';
 
 import { postNewRollingPaper } from '@/apis/rolling';
@@ -11,6 +11,7 @@ interface AddRollingPaperModalProps {
 export default function AddRollingPaperModal({ onClose }: AddRollingPaperModalProps) {
   const [title, setTitle] = useState('');
   const [error, setError] = useState('');
+  const queryClient = useQueryClient();
 
   const { mutate } = useMutation({
     mutationFn: () => postNewRollingPaper(title),
@@ -18,6 +19,8 @@ export default function AddRollingPaperModal({ onClose }: AddRollingPaperModalPr
       setTitle('');
       setError('');
       onClose();
+      // TODO: 페이지네이션 적용 후, 현재 page에 대한 캐싱 날리는 방식으로 변경
+      queryClient.invalidateQueries({ queryKey: ['admin-rolling-paper'] });
     },
     onError: () => {
       setError('편지 작성에 실패했어요. 다시 시도해주세요.');

--- a/src/pages/Admin/components/RollingPaperItem.tsx
+++ b/src/pages/Admin/components/RollingPaperItem.tsx
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
 
-import { deleteRollingPaper } from '@/apis/rolling';
+import { deleteRollingPaper, patchRollingPaper } from '@/apis/rolling';
 import { DeleteIcon } from '@/assets/icons';
 
 interface RollingPaperItemProps {
@@ -21,23 +22,43 @@ export default function RollingPaperItem({ information }: RollingPaperItemProps)
     },
   });
 
+  const { mutate: toggleStatus } = useMutation({
+    mutationFn: () => patchRollingPaper(information.eventPostId),
+    onSuccess: () => {
+      // TODO: 기존 데이터 수정하는 방식으로 ㄱㄱㄱㄱㄱㄱㄱ
+      // 일단 임시로 캐싱 날리기
+      queryClient.invalidateQueries({ queryKey: ['admin-rolling-paper'] });
+    },
+    onError: (err: AxiosError<{ code: string; message: string }>) => {
+      if (err.response?.data.code === 'EVENT-004') {
+        alert(err.response.data.message);
+      }
+      console.error(err);
+    },
+  });
+
+  // TODO: 진짜 삭제하겠냐고 물어보기
   return (
     <tr className="border-gray-40 h-14 border-b">
       <td className="w-14 text-center">{information.eventPostId}</td>
-      <td className="text-left">{information.title}</td>
+      <td className="text-left">
+        <div>
+          {information.used && (
+            <span className="mr-2 rounded-full border border-amber-500 bg-amber-100/70 px-3 py-0.5 whitespace-nowrap text-amber-500">
+              진행 중
+            </span>
+          )}
+          {information.title}
+        </div>
+      </td>
       <td className="text-center">
-        {information.used ? (
-          <span className="rounded-full border border-amber-500 bg-amber-100/70 px-4 py-1.5 whitespace-nowrap text-amber-500">
-            진행 중
-          </span>
-        ) : (
-          <button
-            type="button"
-            className="hover:bg-gray-10 text-gray-60 rounded-md px-3 py-1 hover:text-black"
-          >
-            진행하기
-          </button>
-        )}
+        <button
+          type="button"
+          className="hover:bg-gray-10 text-gray-60 rounded-md px-3 py-1 hover:text-black"
+          onClick={() => toggleStatus()}
+        >
+          {information.used ? '중단하기' : '진행하기'}
+        </button>
       </td>
       <td className="w-6">
         {!information.used && (
@@ -52,30 +73,4 @@ export default function RollingPaperItem({ information }: RollingPaperItemProps)
       </td>
     </tr>
   );
-}
-
-{
-  /* <tr className="border-gray-40 h-14 border-b">
-  <td className="w-14 text-center">2</td>
-  <td className="text-left">
-    침수 피해를 복구중인 포스코 임직원 분들에게 응원의 메시지를 보내주세요!
-  </td>
-  <td className="w-30 text-center">12</td>
-  <td className="w-30 px-2 text-center">
-    <button
-      type="button"
-      className="hover:bg-gray-10 text-gray-60 rounded-md px-3 py-1 hover:text-black"
-    >
-      진행하기
-    </button>
-  </td>
-  <td>
-    <button
-      type="button"
-      className="text-gray-60 flex items-center justify-center p-1 hover:text-black"
-    >
-      <DeleteIcon className="h-5 w-5" />
-    </button>
-  </td>
-</tr>; */
 }

--- a/src/pages/Admin/components/RollingPaperItem.tsx
+++ b/src/pages/Admin/components/RollingPaperItem.tsx
@@ -1,0 +1,64 @@
+import { DeleteIcon } from '@/assets/icons';
+
+interface RollingPaperItemProps {
+  information: AdminRollingPaperInformation;
+}
+
+export default function RollingPaperItem({ information }: RollingPaperItemProps) {
+  return (
+    <tr className="border-gray-40 h-14 border-b">
+      <td className="w-14 text-center">{information.eventPostId}</td>
+      <td className="text-left">{information.title}</td>
+      <td className="text-center">
+        {information.used ? (
+          <span className="rounded-full border border-amber-500 bg-amber-100/70 px-4 py-1.5 whitespace-nowrap text-amber-500">
+            진행 중
+          </span>
+        ) : (
+          <button
+            type="button"
+            className="hover:bg-gray-10 text-gray-60 rounded-md px-3 py-1 hover:text-black"
+          >
+            진행하기
+          </button>
+        )}
+      </td>
+      <td>
+        {!information.used && (
+          <button
+            type="button"
+            className="text-gray-60 flex items-center justify-center p-1 hover:text-black"
+          >
+            <DeleteIcon className="h-5 w-5" />
+          </button>
+        )}
+      </td>
+    </tr>
+  );
+}
+
+{
+  /* <tr className="border-gray-40 h-14 border-b">
+  <td className="w-14 text-center">2</td>
+  <td className="text-left">
+    침수 피해를 복구중인 포스코 임직원 분들에게 응원의 메시지를 보내주세요!
+  </td>
+  <td className="w-30 text-center">12</td>
+  <td className="w-30 px-2 text-center">
+    <button
+      type="button"
+      className="hover:bg-gray-10 text-gray-60 rounded-md px-3 py-1 hover:text-black"
+    >
+      진행하기
+    </button>
+  </td>
+  <td>
+    <button
+      type="button"
+      className="text-gray-60 flex items-center justify-center p-1 hover:text-black"
+    >
+      <DeleteIcon className="h-5 w-5" />
+    </button>
+  </td>
+</tr>; */
+}

--- a/src/pages/Admin/components/RollingPaperItem.tsx
+++ b/src/pages/Admin/components/RollingPaperItem.tsx
@@ -1,3 +1,6 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { deleteRollingPaper } from '@/apis/rolling';
 import { DeleteIcon } from '@/assets/icons';
 
 interface RollingPaperItemProps {
@@ -5,6 +8,19 @@ interface RollingPaperItemProps {
 }
 
 export default function RollingPaperItem({ information }: RollingPaperItemProps) {
+  const queryClient = useQueryClient();
+
+  const { mutate: deleteMutate } = useMutation({
+    mutationFn: () => deleteRollingPaper(information.eventPostId),
+    onSuccess: () => {
+      // TODO: 페이지네이션 적용 후, 현재 page에 대한 캐싱 날리는 방식으로 변경
+      queryClient.invalidateQueries({ queryKey: ['admin-rolling-paper'] });
+    },
+    onError: (err) => {
+      console.error(err);
+    },
+  });
+
   return (
     <tr className="border-gray-40 h-14 border-b">
       <td className="w-14 text-center">{information.eventPostId}</td>
@@ -23,11 +39,12 @@ export default function RollingPaperItem({ information }: RollingPaperItemProps)
           </button>
         )}
       </td>
-      <td>
+      <td className="w-6">
         {!information.used && (
           <button
             type="button"
             className="text-gray-60 flex items-center justify-center p-1 hover:text-black"
+            onClick={() => deleteMutate()}
           >
             <DeleteIcon className="h-5 w-5" />
           </button>

--- a/src/pages/RollingPaper/components/CommentDetailModal.tsx
+++ b/src/pages/RollingPaper/components/CommentDetailModal.tsx
@@ -20,7 +20,7 @@ const CommentDetailModal = ({ comment, isWriter, onClose, onDelete }: CommentDet
 
         <MemoWrapper className="mt-1 flex max-h-1/2 w-78 overflow-y-auto px-5 text-black">
           <div className="z-1 flex flex-col gap-3">
-            <p className="body-r leading-[26px]">{comment.content}</p>
+            <p className="body-r leading-[26px] whitespace-pre-wrap">{comment.content}</p>
             <p className="body-m place-self-end">From. {comment.zipCode}</p>
           </div>
         </MemoWrapper>

--- a/src/pages/RollingPaper/index.tsx
+++ b/src/pages/RollingPaper/index.tsx
@@ -33,14 +33,14 @@ const RollingPaperPage = () => {
       queryClient.setQueryData(['rolling-paper', id], (oldData: RollingPaper) => {
         if (!oldData) return oldData;
 
-        // return {
-        //   ...oldData,
-        //   eventPostComments: oldData.eventPostComments.filter(
-        //     (comment: RollingPaperComment) => comment.commentId !== data.commentId,
-        //   ),
-        // };
-        console.log(data, oldData);
-        return oldData;
+        return {
+          ...oldData,
+          eventPostComments: {
+            content: oldData.eventPostComments.content.filter(
+              (comment: RollingPaperComment) => comment.commentId !== data.commentId,
+            ),
+          },
+        };
       });
 
       setActiveDeleteModal(false);
@@ -102,6 +102,13 @@ const RollingPaperPage = () => {
                 />
               ))}
           </MasonryInfiniteGrid>
+          {isSuccess && data.eventPostComments.content.length === 0 && (
+            <p className="body-sb text-gray-60 my-20 text-center">
+              아직 등록된 편지가 없어요.
+              <br />
+              첫번째로 편지를 남겨볼까요?
+            </p>
+          )}
         </section>
         <WriteCommentButton rollingPaperId={id} />
       </main>

--- a/src/pages/RollingPaper/index.tsx
+++ b/src/pages/RollingPaper/index.tsx
@@ -12,19 +12,17 @@ import Header from '@/layouts/Header';
 import Comment from './components/Comment';
 import CommentDetailModal from './components/CommentDetailModal';
 import WriteCommentButton from './components/WriteCommentButton';
-
-// TODO: 로그인 구현 완료 시, 더미 완전히 제거
-const DUMMY_USER_ZIP_CODE = '1DR41';
-const DUMMY_MESSAGE_COUNT = 20;
+import useAuthStore from '@/stores/authStore';
 
 const RollingPaperPage = () => {
   const id = useParams().id ?? '';
   const [activeComment, setActiveComment] = useState<RollingPaperComment | null>(null);
   const [activeDetailModal, setActiveDetailModal] = useState(false);
   const [activeDeleteModal, setActiveDeleteModal] = useState(false);
+  const zipCode = useAuthStore((props) => props.zipCode);
   const queryClient = useQueryClient();
 
-  const { data } = useQuery({
+  const { data, isSuccess } = useQuery({
     queryKey: ['rolling-paper', id],
     queryFn: () => getRollingPaperDetail(id),
   });
@@ -35,12 +33,14 @@ const RollingPaperPage = () => {
       queryClient.setQueryData(['rolling-paper', id], (oldData: RollingPaper) => {
         if (!oldData) return oldData;
 
-        return {
-          ...oldData,
-          eventPostComments: oldData.eventPostComments.filter(
-            (comment: RollingPaperComment) => comment.commentId !== data.commentId,
-          ),
-        };
+        // return {
+        //   ...oldData,
+        //   eventPostComments: oldData.eventPostComments.filter(
+        //     (comment: RollingPaperComment) => comment.commentId !== data.commentId,
+        //   ),
+        // };
+        console.log(data, oldData);
+        return oldData;
       });
 
       setActiveDeleteModal(false);
@@ -56,7 +56,7 @@ const RollingPaperPage = () => {
       {activeDetailModal && activeComment && (
         <CommentDetailModal
           comment={activeComment}
-          isWriter={activeComment.zipCode === DUMMY_USER_ZIP_CODE}
+          isWriter={activeComment.zipCode === zipCode}
           onClose={() => {
             setActiveDetailModal(false);
             setActiveComment(null);
@@ -85,11 +85,13 @@ const RollingPaperPage = () => {
       <Header />
       <main className="flex grow flex-col items-center px-5 pt-20 pb-12">
         <PageTitle className="mb-18 max-w-73 text-center">{data?.title}</PageTitle>
-        <p className="body-sb text-gray-60 mb-2 w-full">등록된 편지 {DUMMY_MESSAGE_COUNT}</p>
+        <p className="body-sb text-gray-60 mb-2 w-full">
+          등록된 편지 {data ? data.eventPostComments.content.length : 0}
+        </p>
         <section className="w-full">
           <MasonryInfiniteGrid column={2} align="stretch" gap={16}>
-            {data &&
-              data.eventPostComments.map((comment) => (
+            {isSuccess &&
+              data.eventPostComments.content.map((comment) => (
                 <Comment
                   key={comment.commentId}
                   comment={comment}

--- a/src/styles/animations.css
+++ b/src/styles/animations.css
@@ -6,7 +6,7 @@
   --animate-rotate-show: rotate-show 1s ease-in-out forwards;
   --animate-blink: showing 0.3s forwards;
   --animate-login-move-up-down: move-up-down 3s ease-in-out infinite;
-  --animate-marquee: marquee 10s linear infinite;
+  --animate-marquee: marquee var(--marquee-duration) linear infinite;
 
   @keyframes down {
     0% {
@@ -70,7 +70,7 @@
   /* SpecialLetterBanner 애니메이션 */
   @keyframes marquee {
     0% {
-      transform: translateX(10%);
+      transform: translateX(100%);
     }
     100% {
       transform: translateX(-100%);

--- a/src/styles/preflight.css
+++ b/src/styles/preflight.css
@@ -4,6 +4,7 @@
   :root {
     --vh: 1vh;
     --vw: 1vw;
+    --marquee-duration: 10s;
   }
 
   * {

--- a/src/types/rolling.d.ts
+++ b/src/types/rolling.d.ts
@@ -13,16 +13,6 @@ interface RollingPaperComment {
   content: string;
 }
 
-interface RollingPaper extends RollingPaperInformation {
-  eventPostComments: {
-    content: RollingPaperComment[];
-    currentPage: number;
-    size: number;
-    totalElements: number;
-    totalPages: number;
-  };
-}
-
 interface PaginationData<T> {
   content: T[];
   currentPage: number;
@@ -31,4 +21,8 @@ interface PaginationData<T> {
   totalPages: number;
 }
 
-type RollingPaperList = PaginationData<AdminRollingPaperInformation>;
+interface RollingPaperList extends PaginationData<AdminRollingPaperInformation> {}
+
+interface RollingPaper extends RollingPaperInformation {
+  eventPostComments: PaginationData<RollingPaperComment>;
+}

--- a/src/types/rolling.d.ts
+++ b/src/types/rolling.d.ts
@@ -3,6 +3,10 @@ interface RollingPaperInformation {
   title: string;
 }
 
+interface AdminRollingPaperInformation extends RollingPaperInformation {
+  used: boolean;
+}
+
 interface RollingPaperComment {
   commentId: number;
   zipCode: string;
@@ -10,5 +14,21 @@ interface RollingPaperComment {
 }
 
 interface RollingPaper extends RollingPaperInformation {
-  eventPostComments: RollingPaperComment[];
+  eventPostComments: {
+    content: RollingPaperComment[];
+    currentPage: number;
+    size: number;
+    totalElements: number;
+    totalPages: number;
+  };
 }
+
+interface PaginationData<T> {
+  content: T[];
+  currentPage: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+}
+
+type RollingPaperList = PaginationData<AdminRollingPaperInformation>;


### PR DESCRIPTION
## ✅ 요약

- resolved #51 
- 롤링페이퍼 배포된 api로 연결 수정

## 🪄 변경사항

- 롤링페이퍼 편지 목록 api의 응답값이 수정되어 구조를 변경했습니다.
- 관리자 페이지에 롤링페이퍼 생성, 삭제, 활성화 수종 api 연동했습니다.
- 롤링페이퍼 공지 애니메이션이 아쉬워서 수정했습니다!
  - 텍스트가 영역을 벗어나면 애니메이션 활성화, 벗어나지 않으면 비활성화
  - 텍스트 길이에 따른 애니메이션 사이클 동적으로 반영
- 롤링페이퍼가 진행되지 않을 때도 있어서 이에 대한 처리도 함께 진행했어요!

## 🖼️ 결과 화면 (선택)

https://github.com/user-attachments/assets/2831d86e-2b3b-4ef3-a992-662a3cdd07c0

https://github.com/user-attachments/assets/3b88fae7-2562-4042-9983-bfcdfa72d5db


## 💬 리뷰어에게 전할 말 (선택)

- 관리자 페이지에 페이지네이션을 적용해야 해요! 지원님이 작업해주셨다고 들어서 추후에 적용 작업 진행하겠습니다.
- 롤링페이퍼에 무한 스크롤이 적용되어야 해요! 일단은 QA를 위해 간단하게만 구현해두어 무한 스크롤이 반영되지 않습니다 (최근 10개값만 보여요) 이것도 추후에 작업해두도록 할게요.
- 관리자 페이지에서 삭제할 때도 모달이 나오면 좋을 것 같아요. 이런 디테일도 추후에 작업하도록 할게요.
- 지금 api에서 어쩔 수 없이 에러가 반환되고, 그 에러를 핸들링하는 로직이 발생하는데 아무래도 interceptor에서 에러가 발생하면 로그아웃을 시키는 것 같아요! 이 부분은 개선이 필요해보여요
