### PR TITLE
feat: 편지 공유 요청 수신 조회 기능 구현

### DIFF
--- a/src/apis/incomingLetters.ts
+++ b/src/apis/incomingLetters.ts
@@ -1,13 +1,9 @@
 import client from './client';
 
-export const getIncomingLetters = async (token: string) => {
+export const getIncomingLetters = async () => {
   try {
-    const { data } = await client.get('/api/letters?status=delivery', {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-    });
-    console.log('불러온 데이터', data);
+    const { data } = await client.get('/api/letters?status=delivery');
+    console.log('오고있는 편지 데이터', data);
     return data;
   } catch (error) {
     console.error('❌오고 있는 편지 목록을 불러오던 중 에러 발생', error);

--- a/src/apis/share.ts
+++ b/src/apis/share.ts
@@ -21,13 +21,22 @@ export interface SharePost {
   letters: ShareLetter[];
 }
 
-// 페이징 포함
+// 공유 게시글 목록 조회 - 페이징 포함
 export interface SharePostResponse {
   content: SharePost[];
   currentPage: number;
   size: number;
   totalElements: number;
   totalPages: number;
+}
+
+// 편지 공유 요청 수신 조회
+export interface ShareProposal {
+  shareProposalId: number;
+  requesterZipCode: string;
+  recipientZipCode: string;
+  message: string;
+  status: 'REJECTED' | 'APPROVED' | 'PENDING';
 }
 
 // 편지 공유 수락 / 거절
@@ -81,6 +90,19 @@ export const postShareProposals = async (
   } catch (error) {
     console.error('❌ 공유 요청 보내기 중 에러가 발생했습니다', error);
     throw new Error('공유 요청 실패');
+  }
+};
+
+// 편지 공유 요청 수신 조회
+export const getShareProposalList = async () => {
+  try {
+    const response = await client.get('/api/share-proposals/inbox');
+    console.log(`🌟공유 요청 목록`, response.data);
+
+    return response.data.data;
+  } catch (error) {
+    console.error('❌ 편지 공유 요청을 조회하던 중 에러가 발생했습니다', error);
+    throw error;
   }
 };
 

--- a/src/pages/Home/components/ShowDraftModal.tsx
+++ b/src/pages/Home/components/ShowDraftModal.tsx
@@ -45,18 +45,22 @@ const ShowDraftModal = ({ onClose }: ShowDraftModalProps) => {
               <p className="caption-r text-black">로그아웃 시 임시 저장된 편지는 사라집니다</p>
             </div>
             <div className="mt-6 flex max-h-60 min-h-auto w-[251px] flex-col gap-[10px] overflow-y-scroll [&::-webkit-scrollbar]:hidden">
-              {draftLetters.map((draft) => (
-                <div
-                  className="text-gray-80 body-m flex h-10 w-full items-center justify-between gap-1 rounded-lg bg-white p-3"
-                  key={draft.letterId}
-                  // onClick={() => handleNavigation(draft.letterId)}
-                >
-                  <p className="truncate">{draft.title}</p>
-                  <div className="text-gray-20">
-                    <DeleteOutlineRoundedIcon />
+              {draftLetters.length > 0 ? (
+                draftLetters.map((draft) => (
+                  <div
+                    className="text-gray-80 body-m flex h-10 w-full items-center justify-between gap-1 rounded-lg bg-white p-3"
+                    key={draft.letterId}
+                    // onClick={() => handleNavigation(draft.letterId)}
+                  >
+                    <p className="truncate">{draft.title}</p>
+                    <div className="text-gray-20">
+                      <DeleteOutlineRoundedIcon />
+                    </div>
                   </div>
-                </div>
-              ))}
+                ))
+              ) : (
+                <p className="caption-m text-center text-gray-50">작성 중인 편지가 없어요</p>
+              )}
             </div>
           </ModalBackgroundWrapper>
         </div>

--- a/src/pages/Home/components/ShowIncomingLettersModal.tsx
+++ b/src/pages/Home/components/ShowIncomingLettersModal.tsx
@@ -29,15 +29,19 @@ const ShowIncomingLettersModal = ({ onClose }: ShowIncomingLettersModalProps) =>
               <p className="caption-r text-black">시간은 실제 시간을 기반으로 책정됩니다.</p>
             </div>
             <div className="mt-6 flex max-h-60 min-h-auto w-[251px] flex-col gap-[10px] overflow-y-scroll [&::-webkit-scrollbar]:hidden">
-              {data.map((letter) => (
-                <div
-                  className="text-gray-80 body-m flex h-10 w-full items-center justify-between gap-1 rounded-lg bg-white p-3"
-                  key={letter.letterId}
-                >
-                  <p className="truncate">{letter.title}</p>
-                  <p>{letter.remainingTime}</p>
-                </div>
-              ))}
+              {data.length > 0 ? (
+                data.map((letter) => (
+                  <div
+                    className="text-gray-80 body-m flex h-10 w-full items-center justify-between gap-1 rounded-lg bg-white p-3"
+                    key={letter.letterId}
+                  >
+                    <p className="truncate">{letter.title}</p>
+                    <p>{letter.remainingTime}</p>
+                  </div>
+                ))
+              ) : (
+                <p className="caption-m text-center text-gray-50">오고 있는 편지가 없어요</p>
+              )}
             </div>
           </ModalBackgroundWrapper>
         </div>

--- a/src/pages/Home/components/ShowShareAccessModal.tsx
+++ b/src/pages/Home/components/ShowShareAccessModal.tsx
@@ -54,15 +54,19 @@ const ShowShareAccessModal = ({ onClose }: ShowShareAccessModalProps) => {
               </p>
             </div>
             <div className="mt-6 flex max-h-60 min-h-auto w-[251px] flex-col gap-[10px] overflow-y-scroll [&::-webkit-scrollbar]:hidden">
-              {shareProposals.map((proposal) => (
-                <button
-                  className="text-gray-80 body-m flex h-10 w-full items-center justify-between gap-1 rounded-lg bg-white p-3"
-                  key={proposal.shareProposalId}
-                  onClick={() => handleNavigation(proposal.shareProposalId)}
-                >
-                  <p>{proposal.requesterZipCode}님의 공유 요청</p>
-                </button>
-              ))}
+              {shareProposals.length > 0 ? (
+                shareProposals.map((proposal) => (
+                  <button
+                    className="text-gray-80 body-m flex h-10 w-full items-center justify-between gap-1 rounded-lg bg-white p-3"
+                    key={proposal.shareProposalId}
+                    onClick={() => handleNavigation(proposal.shareProposalId)}
+                  >
+                    <p>{proposal.requesterZipCode}님의 공유 요청</p>
+                  </button>
+                ))
+              ) : (
+                <p className="caption-m text-center text-gray-50">새로운 공유 요청이 없어요</p>
+              )}
             </div>
           </ModalBackgroundWrapper>
         </div>

--- a/src/pages/Home/components/ShowShareAccessModal.tsx
+++ b/src/pages/Home/components/ShowShareAccessModal.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router';
 
-import { getSharePostDetail, getSharePostList } from '@/apis/share';
-import { SharePostResponse } from '@/apis/share';
+import { getSharePostDetail } from '@/apis/share';
+import { getShareProposalList } from '@/apis/share';
+import { ShareProposal } from '@/apis/share';
 import ModalBackgroundWrapper from '@/components/ModalBackgroundWrapper';
 import ModalOverlay from '@/components/ModalOverlay';
 
@@ -14,25 +15,22 @@ interface ShowShareAccessModalProps {
 const ShowShareAccessModal = ({ onClose }: ShowShareAccessModalProps) => {
   const navigate = useNavigate();
 
-  const [sharePosts, setSharePosts] = useState<SharePostResponse>();
+  const [shareProposals, setShareProposals] = useState<ShareProposal[]>([]);
 
   useEffect(() => {
-    const fetchPosts = async () => {
-      try {
-        const data = await getSharePostList(1, 10);
-        setSharePosts(data);
-      } catch (error) {
-        console.error('❌ 게시글 목록을 불러오는 데 실패했습니다.', error);
-      }
-    };
-
-    fetchPosts();
+    getShareProposalList()
+      .then((data) => {
+        setShareProposals(data || []);
+      })
+      .catch((error) => {
+        console.error('❌ 공유 요청 목록을 불러오는 데 실패했습니다.', error);
+      });
   }, []);
 
-  const handleNavigation = async (sharePostId: number) => {
+  const handleNavigation = async (shareProposalId: number) => {
     try {
-      const postDetail = await getSharePostDetail(sharePostId);
-      navigate(`/board/letter/${sharePostId}`, {
+      const postDetail = await getSharePostDetail(shareProposalId);
+      navigate(`/board/letter/${shareProposalId}`, {
         state: { postDetail, isShareLetterPreview: true },
       });
     } catch (error) {
@@ -56,13 +54,13 @@ const ShowShareAccessModal = ({ onClose }: ShowShareAccessModalProps) => {
               </p>
             </div>
             <div className="mt-6 flex max-h-60 min-h-auto w-[251px] flex-col gap-[10px] overflow-y-scroll [&::-webkit-scrollbar]:hidden">
-              {sharePosts?.content.map((post) => (
+              {shareProposals.map((proposal) => (
                 <button
                   className="text-gray-80 body-m flex h-10 w-full items-center justify-between gap-1 rounded-lg bg-white p-3"
-                  key={post.sharePostId}
-                  onClick={() => handleNavigation(post.sharePostId)}
+                  key={proposal.shareProposalId}
+                  onClick={() => handleNavigation(proposal.shareProposalId)}
                 >
-                  <p>{post.writerZipCode}님의 공유 요청</p>
+                  <p>{proposal.requesterZipCode}님의 공유 요청</p>
                 </button>
               ))}
             </div>

--- a/src/stores/incomingLettersStore.ts
+++ b/src/stores/incomingLettersStore.ts
@@ -12,9 +12,6 @@ interface IncomingLetters {
 
 interface IncomingLettersStore {
   data: IncomingLetters[];
-  arrivedCount: number;
-  message: string;
-  timestamp: string;
   fetchIncomingLetters: () => void;
 }
 
@@ -36,18 +33,12 @@ const calculatingRemainingTime = (deliveryCompletedAt: string): string => {
 
 export const useIncomingLettersStore = create<IncomingLettersStore>((set) => ({
   data: [],
-  arrivedCount: 0,
-  message: '',
-  timestamp: '',
   fetchIncomingLetters: async () => {
     try {
-      const token = localStorage.getItem('token') || '';
-      const data = await getIncomingLetters(token);
+      const data = await getIncomingLetters();
 
-      let arrivedCount = 0;
       const updatedLetters = data.data.map((letter: IncomingLetters) => {
         const remainingTime = calculatingRemainingTime(letter.deliveryCompletedAt);
-        if (remainingTime === '00:00:00') arrivedCount += 1; // 도착한 편지 카운트
 
         return { ...letter, remainingTime };
       });
@@ -57,9 +48,6 @@ export const useIncomingLettersStore = create<IncomingLettersStore>((set) => ({
       );
       set({
         data: inProgressLetters,
-        arrivedCount,
-        message: data.message,
-        timestamp: data.timestamp,
       });
     } catch (error) {
       console.error('❌오고 있는 편지 목록을 불러오던 중 에러 발생', error);

--- a/src/stores/incomingLettersStore.ts
+++ b/src/stores/incomingLettersStore.ts
@@ -46,9 +46,27 @@ export const useIncomingLettersStore = create<IncomingLettersStore>((set) => ({
       const inProgressLetters = updatedLetters.filter(
         (letter: IncomingLetters) => letter.remainingTime !== '00:00:00',
       );
+
       set({
         data: inProgressLetters,
       });
+
+      setInterval(() => {
+        set((state) => {
+          const updatedLetters = state.data.map((letter: IncomingLetters) => {
+            const remainingTime = calculatingRemainingTime(letter.deliveryCompletedAt);
+            return { ...letter, remainingTime };
+          });
+
+          const filteredLetters = updatedLetters.filter(
+            (letter) => letter.remainingTime !== '00:00:00',
+          );
+
+          return {
+            data: filteredLetters,
+          };
+        });
+      }, 1000);
     } catch (error) {
       console.error('❌오고 있는 편지 목록을 불러오던 중 에러 발생', error);
     }


### PR DESCRIPTION
## ✅ 요약

- resolved #78 
- 편지 공유 요청 수신 조회 기능 구현

## 🪄 변경사항
### 편지 공유
- 편지 공유 요청 수신 조회 기능 구현
- 편지 공유 요청 수신 조회 모달에서 데이터가 없을 때 대체 텍스트 추가

### 오고 있는 편지
- 오고 있는 편지 도착까지 걸리는 시간에 카운트다운 로직을 추가
- 오고 있는 편지 모달에서 데이터가 없을 때 대체 텍스트 추가
- `incomingLetters.ts`, `incomingLettersStore.ts` 코드 리팩토링 

### 임시저장 편지
- 임시저장된 편지 모달에서 데이터가 없을 때 대체 텍스트 추가

## 🖼️ 결과 화면 (선택)
![image](https://github.com/user-attachments/assets/d6b7528a-02b4-4331-9c65-241d5573862a)

## 💬 리뷰어에게 전할 말 (선택)

- 화이팅!!! 🫰🏻
