### PR TITLE
feat: 롤링페이퍼 추가 기능 구현

### DIFF
--- a/src/apis/rolling.ts
+++ b/src/apis/rolling.ts
@@ -57,11 +57,19 @@ export const postNewRollingPaper = async (title: string) => {
   }
 };
 
-export const getRollingPaperList = async (): Promise<RollingPaperList> => {
+export const getRollingPaperList = async (
+  page: string | number,
+  size: number,
+): Promise<RollingPaperList> => {
   try {
     const {
       data: { data },
-    } = await client.get('/api/admin/event-posts');
+    } = await client.get('/api/admin/event-posts', {
+      params: {
+        page,
+        size,
+      },
+    });
     return data;
   } catch (error) {
     console.error(error);

--- a/src/apis/rolling.ts
+++ b/src/apis/rolling.ts
@@ -9,10 +9,18 @@ export const getCurrentRollingPaper = async (): Promise<RollingPaperInformation>
 
 export const getRollingPaperDetail = async (
   rollingPaperId: string | number,
+  page: number,
+  size: number,
 ): Promise<RollingPaper> => {
   const {
     data: { data },
-  } = await client.get(`/api/event-posts/${rollingPaperId}`);
+  } = await client.get(`/api/event-posts/${rollingPaperId}`, {
+    params: {
+      page,
+      size,
+    },
+  });
+  console.log(data);
   return data;
 };
 

--- a/src/components/BackgroundBottom.tsx
+++ b/src/components/BackgroundBottom.tsx
@@ -6,7 +6,7 @@ const BackgroundBottom = () => {
   return (
     <BackgroundImageWrapper
       as="div"
-      className="fixed bottom-[-40px] left-1/2 z-[-10] h-42 w-full -translate-x-1/2 opacity-70"
+      className="fixed bottom-[-40px] left-1/2 h-42 w-full -translate-x-1/2 opacity-70"
       imageUrl={BgItem}
     />
   );

--- a/src/components/ConfirmModal.tsx
+++ b/src/components/ConfirmModal.tsx
@@ -22,7 +22,6 @@ const ConfirmModal = ({
   onCancel,
   onConfirm,
 }: ConfirmModalProps) => {
-  // TODO: 전역 상태로 관리해야하는지 고민
   return (
     <ModalOverlay>
       <div className="w-73">

--- a/src/pages/Admin/RollingPaper.tsx
+++ b/src/pages/Admin/RollingPaper.tsx
@@ -28,7 +28,9 @@ export default function AdminRollingPaper() {
 
   return (
     <>
-      {activeModal && <AddRollingPaperModal onClose={() => setActiveModal(false)} />}
+      {activeModal && (
+        <AddRollingPaperModal currentPage={currentPage} onClose={() => setActiveModal(false)} />
+      )}
       <PageTitle>게시판 관리 / 롤링 페이퍼 설정</PageTitle>
       <WrapperFrame>
         <section className="flex items-center">
@@ -56,7 +58,11 @@ export default function AdminRollingPaper() {
               </thead>
               <tbody>
                 {data.content.map((rollingPaper) => (
-                  <RollingPaperItem key={rollingPaper.eventPostId} information={rollingPaper} />
+                  <RollingPaperItem
+                    key={rollingPaper.eventPostId}
+                    information={rollingPaper}
+                    currentPage={currentPage}
+                  />
                 ))}
               </tbody>
             </table>

--- a/src/pages/Admin/RollingPaper.tsx
+++ b/src/pages/Admin/RollingPaper.tsx
@@ -9,13 +9,22 @@ import PageTitle from './components/AdminPageTitle';
 import RollingPaperItem from './components/RollingPaperItem';
 import WrapperFrame from './components/WrapperFrame';
 import WrapperTitle from './components/WrapperTitle';
+import PagenationNavigation from './components/PagenationNavigation';
+
+const SIZE = 10;
 
 export default function AdminRollingPaper() {
   const [activeModal, setActiveModal] = useState(false);
-  const { data, isLoading, isSuccess } = useQuery({
-    queryKey: ['admin-rolling-paper'],
-    queryFn: getRollingPaperList,
+  const [currentPage, setCurrentPage] = useState<string>('1');
+  const { data, isLoading, isSuccess, refetch } = useQuery({
+    queryKey: ['admin-rolling-paper', currentPage],
+    queryFn: () => getRollingPaperList(currentPage ?? 1, SIZE),
   });
+
+  const handleNowPage = (page: string) => {
+    setCurrentPage(page);
+    refetch();
+  };
 
   return (
     <>
@@ -58,7 +67,11 @@ export default function AdminRollingPaper() {
             )}
           </>
         )}
-        {/* TODO: 페이지네이션 적용 */}
+        <PagenationNavigation
+          totalPage={Number(data?.totalPages)}
+          buttonLength={5}
+          handlePageNumberButtonClick={handleNowPage}
+        />
       </WrapperFrame>
     </>
   );

--- a/src/pages/Admin/components/AddRollingPaperModal.tsx
+++ b/src/pages/Admin/components/AddRollingPaperModal.tsx
@@ -5,10 +5,11 @@ import { postNewRollingPaper } from '@/apis/rolling';
 import ModalOverlay from '@/components/ModalOverlay';
 
 interface AddRollingPaperModalProps {
+  currentPage: number | string;
   onClose: () => void;
 }
 
-export default function AddRollingPaperModal({ onClose }: AddRollingPaperModalProps) {
+export default function AddRollingPaperModal({ currentPage, onClose }: AddRollingPaperModalProps) {
   const [title, setTitle] = useState('');
   const [error, setError] = useState('');
   const queryClient = useQueryClient();
@@ -19,8 +20,7 @@ export default function AddRollingPaperModal({ onClose }: AddRollingPaperModalPr
       setTitle('');
       setError('');
       onClose();
-      // TODO: 페이지네이션 적용 후, 현재 page에 대한 캐싱 날리는 방식으로 변경
-      queryClient.invalidateQueries({ queryKey: ['admin-rolling-paper'] });
+      queryClient.invalidateQueries({ queryKey: ['admin-rolling-paper', currentPage] });
     },
     onError: () => {
       setError('편지 작성에 실패했어요. 다시 시도해주세요.');

--- a/src/pages/Admin/components/PagenationNavigation.tsx
+++ b/src/pages/Admin/components/PagenationNavigation.tsx
@@ -50,13 +50,13 @@ export default function PagenationNavigation({
     }
   };
 
-  const buttonStyle = 'border bg-white px-2 py-1 disabled:bg-gray-20';
+  const buttonStyle = 'rounded-full bg-white w-8 h-8 disabled:bg-gray-20';
 
   return (
     <div className="mt-5 flex h-10 w-full items-center justify-center">
-      <div className="flex items-center">
+      <div className="flex items-center gap-2">
         <button
-          className={twMerge(buttonStyle)}
+          className={twMerge(buttonStyle, 'w-14')}
           disabled={nowSection <= 0}
           onClick={() => {
             handlePrevButtonClick();
@@ -69,7 +69,7 @@ export default function PagenationNavigation({
           return (
             <button
               key={num}
-              className={twMerge(buttonStyle, nowPageNumberAt === num && 'bg-accent-3')}
+              className={twMerge(buttonStyle, nowPageNumberAt === num && 'bg-primary-2/50')}
               onClick={() => {
                 handlePageButtonClick(num);
               }}
@@ -79,7 +79,7 @@ export default function PagenationNavigation({
           );
         })}
         <button
-          className={twMerge(buttonStyle)}
+          className={twMerge(buttonStyle, 'w-14')}
           disabled={nowSection >= totalSection}
           onClick={() => {
             handleNextButtonClick();

--- a/src/pages/LetterBoard/index.tsx
+++ b/src/pages/LetterBoard/index.tsx
@@ -56,7 +56,7 @@ const LetterBoardPage = () => {
 
   return (
     <>
-      <main className="mt-[-25px] flex grow flex-col px-5 pt-20 pb-10">
+      <main className="z-1 mt-[-25px] flex grow flex-col px-5 pt-20 pb-10">
         <>
           <NoticeRollingPaper />
           <PageTitle className="mx-auto mt-4">게시판</PageTitle>

--- a/src/pages/MyPage/components/MyBoardPage.tsx
+++ b/src/pages/MyPage/components/MyBoardPage.tsx
@@ -39,7 +39,7 @@ const MyBoardPage = () => {
   }
   return (
     <>
-      <main className={twMerge('flex grow flex-col px-5 pt-20 pb-10')}>
+      <main className={twMerge('z-1 flex grow flex-col px-5 pt-20 pb-10')}>
         <PageTitle className="mx-auto mb-11">내가 올린 게시물</PageTitle>
         {isLoading ? (
           <p>loading</p>

--- a/src/pages/RollingPaper/components/WriteCommentButton.tsx
+++ b/src/pages/RollingPaper/components/WriteCommentButton.tsx
@@ -4,8 +4,7 @@ import { useState } from 'react';
 import { postRollingPaperComment } from '@/apis/rolling';
 import EnvelopeImg from '@/assets/images/closed-letter.png';
 import MessageModal from '@/components/MessageModal';
-
-const DUMMY_USER_ZIP_CODE = '1DR41';
+import useAuthStore from '@/stores/authStore';
 
 interface WriteCommentButtonProps {
   rollingPaperId: string;
@@ -15,12 +14,12 @@ const WriteCommentButton = ({ rollingPaperId }: WriteCommentButtonProps) => {
   const [activeMessageModal, setActiveMessageModal] = useState(false);
   const [newMessage, setNewMessage] = useState('');
   const [error, setError] = useState<string | null>(null);
+  const zipCode = useAuthStore((props) => props.zipCode);
   const queryClient = useQueryClient();
 
   const { mutate } = useMutation({
     mutationFn: (content: string) => postRollingPaperComment(rollingPaperId, content),
-    onSuccess: (data) => {
-      console.log(data);
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['rolling-paper', rollingPaperId] });
       setNewMessage('');
       setError(null);
@@ -37,7 +36,6 @@ const WriteCommentButton = ({ rollingPaperId }: WriteCommentButtonProps) => {
 
   const handleAddComment = () => {
     console.log(rollingPaperId);
-    // 추가 가능한지 조건 확인
     if (newMessage.trim() === '') {
       setError('편지를 작성해주세요.');
       return;
@@ -59,12 +57,12 @@ const WriteCommentButton = ({ rollingPaperId }: WriteCommentButtonProps) => {
           onComplete={handleAddComment}
         >
           <p className="body-r text-accent-1 mt-1">{error}</p>
-          <p className="body-r mt-5 text-end text-black">From. {DUMMY_USER_ZIP_CODE}</p>
+          <p className="body-r mt-5 text-end text-black">From. {zipCode}</p>
         </MessageModal>
       )}
       <button
         type="button"
-        className="fixed bottom-7.5 left-5 overflow-hidden rounded-sm"
+        className="fixed bottom-7.5 left-5 z-10 overflow-hidden rounded-sm"
         onClick={() => setActiveMessageModal(true)}
       >
         <img src={EnvelopeImg} alt="편지지 이미지" className="h-12 w-auto opacity-70" />

--- a/src/pages/RollingPaper/components/WriteCommentButton.tsx
+++ b/src/pages/RollingPaper/components/WriteCommentButton.tsx
@@ -62,7 +62,7 @@ const WriteCommentButton = ({ rollingPaperId }: WriteCommentButtonProps) => {
       )}
       <button
         type="button"
-        className="fixed bottom-7.5 left-5 z-10 overflow-hidden rounded-sm"
+        className="sticky bottom-8 z-10 mt-4 -mb-4 self-start overflow-hidden rounded-sm"
         onClick={() => setActiveMessageModal(true)}
       >
         <img src={EnvelopeImg} alt="편지지 이미지" className="h-12 w-auto opacity-70" />

--- a/src/pages/RollingPaper/index.tsx
+++ b/src/pages/RollingPaper/index.tsx
@@ -1,6 +1,6 @@
 import { MasonryInfiniteGrid } from '@egjs/react-infinitegrid';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useState } from 'react';
+import { useMutation, useInfiniteQuery, useQueryClient } from '@tanstack/react-query';
+import { useState, useCallback } from 'react';
 import { useParams } from 'react-router';
 
 import { deleteRollingPaperComment, getRollingPaperDetail } from '@/apis/rolling';
@@ -14,6 +14,8 @@ import CommentDetailModal from './components/CommentDetailModal';
 import WriteCommentButton from './components/WriteCommentButton';
 import useAuthStore from '@/stores/authStore';
 
+const MESSAGE_SIZE = 10;
+
 const RollingPaperPage = () => {
   const id = useParams().id ?? '';
   const [activeComment, setActiveComment] = useState<RollingPaperComment | null>(null);
@@ -22,34 +24,35 @@ const RollingPaperPage = () => {
   const zipCode = useAuthStore((props) => props.zipCode);
   const queryClient = useQueryClient();
 
-  const { data, isSuccess } = useQuery({
+  const { data, isSuccess, fetchNextPage, hasNextPage, isFetchingNextPage } = useInfiniteQuery({
     queryKey: ['rolling-paper', id],
-    queryFn: () => getRollingPaperDetail(id),
+    queryFn: ({ pageParam = 1 }) => getRollingPaperDetail(id, pageParam, MESSAGE_SIZE),
+    getNextPageParam: (lastPage) => {
+      const { currentPage, totalPages } = lastPage.eventPostComments;
+      return currentPage < totalPages ? currentPage + 1 : undefined;
+    },
+    initialPageParam: 1,
   });
 
   const { mutate: deleteComment } = useMutation({
     mutationFn: (rollingPaperId: number | string) => deleteRollingPaperComment(rollingPaperId),
-    onSuccess: (data) => {
-      queryClient.setQueryData(['rolling-paper', id], (oldData: RollingPaper) => {
-        if (!oldData) return oldData;
-
-        return {
-          ...oldData,
-          eventPostComments: {
-            content: oldData.eventPostComments.content.filter(
-              (comment: RollingPaperComment) => comment.commentId !== data.commentId,
-            ),
-          },
-        };
-      });
-
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['rolling-paper', id] });
       setActiveDeleteModal(false);
       setActiveComment(null);
     },
-    onError: (err) => {
-      console.error(err);
+    onError: () => {
+      alert('편지 삭제에 실패했어요. 다시 시도해주세요');
     },
   });
+
+  const handleLoadMore = useCallback(() => {
+    if (!isFetchingNextPage && hasNextPage) fetchNextPage();
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
+
+  const allComments = data?.pages.flatMap((page) => page.eventPostComments.content) || [];
+  const totalComments = data?.pages[0]?.eventPostComments.totalElements || 0;
+  const title = data?.pages[0]?.title || '';
 
   return (
     <>
@@ -84,14 +87,12 @@ const RollingPaperPage = () => {
       )}
       <Header />
       <main className="flex grow flex-col items-center px-5 pt-20 pb-12">
-        <PageTitle className="mb-18 max-w-73 text-center">{data?.title}</PageTitle>
-        <p className="body-sb text-gray-60 mb-2 w-full">
-          등록된 편지 {data ? data.eventPostComments.content.length : 0}
-        </p>
+        <PageTitle className="mb-18 max-w-73 text-center">{title}</PageTitle>
+        <p className="body-sb text-gray-60 mb-2 w-full">등록된 편지 {totalComments}</p>
         <section className="w-full">
-          <MasonryInfiniteGrid column={2} align="stretch" gap={16}>
+          <MasonryInfiniteGrid column={2} align="stretch" gap={16} onRequestAppend={handleLoadMore}>
             {isSuccess &&
-              data.eventPostComments.content.map((comment) => (
+              allComments.map((comment) => (
                 <Comment
                   key={comment.commentId}
                   comment={comment}
@@ -102,12 +103,15 @@ const RollingPaperPage = () => {
                 />
               ))}
           </MasonryInfiniteGrid>
-          {isSuccess && data.eventPostComments.content.length === 0 && (
+          {isSuccess && allComments.length === 0 && (
             <p className="body-sb text-gray-60 my-20 text-center">
               아직 등록된 편지가 없어요.
               <br />
               첫번째로 편지를 남겨볼까요?
             </p>
+          )}
+          {isFetchingNextPage && (
+            <p className="body-sb text-gray-60 my-4 text-center">Loading...</p>
           )}
         </section>
         <WriteCommentButton rollingPaperId={id} />

--- a/src/pages/RollingPaper/index.tsx
+++ b/src/pages/RollingPaper/index.tsx
@@ -86,7 +86,7 @@ const RollingPaperPage = () => {
         />
       )}
       <Header />
-      <main className="flex grow flex-col items-center px-5 pt-20 pb-12">
+      <main className="z-1 flex grow flex-col items-center px-5 pt-20 pb-12">
         <PageTitle className="mb-18 max-w-73 text-center">{title}</PageTitle>
         <p className="body-sb text-gray-60 mb-2 w-full">등록된 편지 {totalComments}</p>
         <section className="w-full">


### PR DESCRIPTION
## ✅ 요약

- resolved #91 
- 롤링페이퍼 관련 추가 기능 구현

## 🪄 변경사항

### 롤링페이퍼 페이지
- 무한스크롤 적용 (useInfiniteQuery & MasonryInfiniteGrid)

### 롤링페이퍼 관리자 페이지
- 삭제 버튼 클릭 시 바로 삭제 -> 모달로 한 번 더 물어본 뒤 삭제
- 페이지네이션 적용
- 페이지네이션 디자인 일부 수정

### QA
- MessageModal에 더미데이터 제거 -> 로그인 한 유저 정보 반영
- 하단 언덕 이미지 깨짐 현상

## 🖼️ 결과 화면 (선택)

https://github.com/user-attachments/assets/3b87a21a-1e80-43a2-bd32-afbff2053909

![image](https://github.com/user-attachments/assets/a8539914-af96-4a42-8f69-0d8423ada474)


## 💬 리뷰어에게 전할 말 (선택)

- 화이팅
