### PR TITLE
fix: 4차 QA 반영 

### DIFF
--- a/src/pages/Home/components/GoToLetterBoard.tsx
+++ b/src/pages/Home/components/GoToLetterBoard.tsx
@@ -4,9 +4,9 @@ import goToLetterBoard from '@/assets/images/go-to-letter-board.png';
 
 const GoToLetterBoard = () => {
   return (
-    <div className="absolute right-[-56%] bottom-[28%] z-9 flex w-full md:right-[-42%]">
+    <div className="absolute right-[-56%] bottom-[28%] z-9 flex w-full md:right-[-42%] lg:right-[-20%]">
       <div className="text-left">
-        <p className="text-gray-60 body-r mb-1 ml-2 dark:text-white">게시판</p>
+        <p className="text-gray-60 body-r mb-1 ml-2">게시판</p>
         <Link to="/board/letter">
           <img
             src={goToLetterBoard}

--- a/src/pages/Share/index.tsx
+++ b/src/pages/Share/index.tsx
@@ -26,7 +26,7 @@ const ShareApprovalPage = () => {
       if (action === 'approve') {
         setToastActive({
           toastType: 'Success',
-          title: '편지를 성공적으로 공유하였습니다. 게시판에서 확인해보세요!',
+          title: '편지가 공유되었습니다. 게시판에서 확인해보세요!',
           time: 5,
         });
       } else {


### PR DESCRIPTION
## ✅ 요약

- resolved #139 
- 4차 QA 반영 

## 🪄 변경사항

- 데스크탑에서 게시판이 안 보이는 오류 해결 - 여전히 태블릿 크기에서는 잘 보입니다.
- 공유 요청 수락 후의 toast 모달 텍스트 길이 조정 - toast에서 2줄로 넘치던 것을 줄였습니다. 

## 🖼️ 결과 화면 (선택)

<img width="1200" alt="image" src="https://github.com/user-attachments/assets/dffdaa1b-c976-4a3f-ab08-7e2f5b8bc76f" />

![image](https://github.com/user-attachments/assets/9772d498-0000-4d08-98ee-cd59776bb0b6)


## 💬 리뷰어에게 전할 말 (선택)

- 💪🏻💪🏻
