### PR TITLE
fix : api reissue 오류 수정

### DIFF
--- a/src/hooks/useServerSentEvents.tsx
+++ b/src/hooks/useServerSentEvents.tsx
@@ -46,6 +46,8 @@ export const useServerSentEvents = () => {
     }
 
     const connectSSE = () => {
+      const accessToken = useAuthStore.getState().accessToken;
+
       try {
         // console.log('구독 시작');
         sourceRef.current = new EventSourcePolyfill(

--- a/src/layouts/PrivateRoute.tsx
+++ b/src/layouts/PrivateRoute.tsx
@@ -6,7 +6,7 @@ import { useServerSentEvents } from '@/hooks/useServerSentEvents';
 import Toast from '@/components/Toast';
 
 export default function PrivateRoute() {
-  useServerSentEvents();
+  // useServerSentEvents();
   const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
   const navigate = useNavigate();
 


### PR DESCRIPTION
## ✅ 요약

- resolved #151
- api reissue 오류 수정

## 🪄 변경사항

- SSE의 API와 axios의 API가 독립적으로 실행되고 있어 토큰 재발급 로직(reissue)가 동시에 발생하면 리이슈가 중단되는 현상 발생
- SSE와 axios 따로따로 reissue함수를 실행하고 있었음 => 코드 retry문을 서로 다르게 적용되어 reissue 충돌이 발생
- zustand 전역변수로 reissue 함수를 통일해 retry를 통일하여 reissue가 중복될 일을 차단함

## 🖼️ 결과 화면 (선택)

## 💬 리뷰어에게 전할 말 (선택)

- 화이팅
