### PR TITLE
perf: 홈 페이지 접근성 향상 

### DIFF
--- a/src/components/MenuButton.tsx
+++ b/src/components/MenuButton.tsx
@@ -53,7 +53,7 @@ export default function MenuButton() {
           <EditNoteRoundedIcon fontSize="medium" />
         </Link>
 
-        <div
+        <button
           className={twMerge(
             'bg-primary-3 fixed bottom-[30px] z-30 flex h-13 w-13 content-center items-center justify-center rounded-full text-white transition-all duration-200 hover:scale-105 active:scale-90',
             isOpen ? 'rotate-90' : 'rotate-0',
@@ -62,7 +62,7 @@ export default function MenuButton() {
           aria-label="메뉴 열기"
         >
           <MenuRoundedIcon />
-        </div>
+        </button>
       </div>
     </>
   );

--- a/src/pages/Home/components/HomeHeader.tsx
+++ b/src/pages/Home/components/HomeHeader.tsx
@@ -19,7 +19,7 @@ const HomeHeader = () => {
           <FlareRoundedIcon className="h-6 w-6 text-white" onClick={toggleTheme} />
         )}
         <NotificationButton />
-        <Link to="/mypage">
+        <Link to="/mypage" aria-label="마이페이지로 이동">
           <PersonIcon className="h-6 w-6 text-white" />
         </Link>
       </div>


### PR DESCRIPTION
## ✅ 요약

- resolved #168 
- 홈 페이지 접근성 향상 

## 🪄 변경사항

- 메뉴 버튼에서 div를 button으로 변경 
- 홈 페이지 header에서 마이페이지로 이동하는 link에 aria-label 추가 

## 🖼️ 결과 화면 (선택)
<img width="1276" alt="image" src="https://github.com/user-attachments/assets/9fb2f8d9-3325-4a1b-b702-08a4d2506fd7" />

## 💬 리뷰어에게 전할 말 (선택)

- 이제 다른 페이지에서도 접근성 향상 해보겠습니다~ 😇
